### PR TITLE
ability to only duplicate unicorn master, while retaining old master

### DIFF
--- a/lib/mina/unicorn/tasks.rb
+++ b/lib/mina/unicorn/tasks.rb
@@ -31,4 +31,9 @@ namespace :unicorn do
   task restart: :remote_environment do
     command restart_unicorn
   end
+
+  desc "Duplicate unicorn service (this does not kill the old master)"
+  task restart: :remote_environment do
+    command duplicate_unicorn
+  end
 end

--- a/lib/mina/unicorn/utility.rb
+++ b/lib/mina/unicorn/utility.rb
@@ -46,6 +46,17 @@ module Mina
       def unicorn_send_signal(signal, pid=get_unicorn_pid)
         "#{unicorn_user} kill -s #{signal} #{pid}"
       end
+      
+      def duplicate_unicorn
+        %{
+          if #{unicorn_is_running?}; then
+            echo "-----> Duplicating Unicorn...";
+            #{unicorn_send_signal("USR2")};
+          else
+            #{start_unicorn}
+          fi
+        }
+      end
 
       private
 
@@ -59,17 +70,6 @@ module Mina
       #
       def remote_process_exists?(pid_file)
         "[ -e #{pid_file} ] && #{unicorn_user} kill -0 `cat #{pid_file}` > /dev/null 2>&1"
-      end
-
-      def duplicate_unicorn
-        %{
-          if #{unicorn_is_running?}; then
-            echo "-----> Duplicating Unicorn...";
-            #{unicorn_send_signal("USR2")};
-          else
-            #{start_unicorn}
-          fi
-        }
       end
 
       # Command to check if Unicorn is running

--- a/lib/mina/unicorn/version.rb
+++ b/lib/mina/unicorn/version.rb
@@ -1,5 +1,5 @@
 module Mina
   module Unicorn
-    VERSION = "2.0.0"
+    VERSION = "2.1.0"
   end
 end


### PR DESCRIPTION
Problem statement: Currently, unicorn:restart always kills the old master in a defined time interval, viz unicorn_restart_sleep_time. If the new master is not loaded and ready to accept requests, it can lead to service downtime.

Exposing the unicorn:duplicate allows clients to only duplicate the unicorn, creating new master. The onus to make sure old master is killed later falls on the client with this. A cool client level solution for this is found here - https://yhbt.net/unicorn/examples/unicorn.conf.rb